### PR TITLE
Added note about HEALTHCHECK directive.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -11,6 +11,9 @@ For now install from this repo:
 ::
     pip install git+git://github.com/tgoodlet/pytest-dockerctl.git
 
+Caveats
+*******
+Your ``Dockerfile`` must have a `HEALTHCHECK`_ directive.
 
 Usage
 *****
@@ -53,3 +56,4 @@ the underlying client via ``dockerctl.client``.
 .. _pytest: https://docs.pytest.org
 .. _docker-py: https://github.com/docker/docker-py
 .. _DockerClient: https://docker-py.readthedocs.io/en/stable/client.html#client-reference
+.. _HEALTHCHECK: https://docs.docker.com/engine/reference/builder/#healthcheck


### PR DESCRIPTION
Added this small note, because `pytest-dockerctl` relies on `docker` to perform health checks on the container to await initialization.

If the `HEALTHCHECK` directive is not present on the container's `Dockerfile`, `pytest-dockerctl` will raise a `KeyError`