### PR TITLE
Don't wait for ip address when using host networking mode

### DIFF
--- a/pytest_dockerctl/__init__.py
+++ b/pytest_dockerctl/__init__.py
@@ -83,7 +83,12 @@ class DockerCtl(object):
         for container in containers:
             log.info("{}:{} Waiting on networking and health check...".format(
                 image, container.short_id))
-            waitfor(container, ('NetworkSettings', 'IPAddress'))
+            if 'network' in kwargs and kwargs['network'] == 'host':
+                waitfor(container, ('NetworkSettings', 'Networks', 'host'))
+
+            else:
+                waitfor(container, ('NetworkSettings', 'IPAddress'))
+
             if has_attr(container, ('State', 'Health', 'Status')):
                 waitfor(container, ('State', 'Health', 'Status'), expect='healthy')
         try:


### PR DESCRIPTION
We don't need to wait for an ip address on container startup if the user selected `host` networking mode.